### PR TITLE
Improvement: do not uninstall my pgtap when I still need it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN git clone git://github.com/theory/pgtap.git \
     && cd pgtap && git checkout tags/$PGTAP_VERSION \
     && make
 
-COPY docker/test.sh /test.sh
-RUN chmod +x /test.sh
+COPY docker/*.sh /
+RUN chmod +x /*.sh
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,30 @@ Environment variables:
 * PASSWORD=""
 * `TESTS="/test/*.sql"`
 * VERBOSE=0
+* INSTALL=1
+* UNINSTALL=1
 
-A full demonstration can be found at [harobed/poc-postgresql-pgTAP](https://github.com/harobed/poc-postgresql-pgTAP)
+Command line options:
+```console
+$ docker run -i -t --rm --name pgtap hbpmip/pgtap:1.0.0-2 -H
+```
+
+Options include:
+* `-v`: verbose
+* `-a`: assume pgTap is already installed, do not install
+* `-k`: keep pgTap installed after tests, do not uninstall
+
+### Installing/uninstalling pgtap into your database
+
+This is useful mostly during test development.
+
+```console
+$ docker run -i -t --rm --name pgtap --link db-under-test:db -e PASSWORD=postgres --entrypoint /install.sh hbpmip/pgtap:1.0.0-2
+```
+
+```console
+$ docker run -i -t --rm --name pgtap --link db-under-test:db -e PASSWORD=postgres --entrypoint /uninstall.sh hbpmip/pgtap:1.0.0-2
+```
 
 ## Build
 
@@ -56,9 +78,15 @@ Run: `./build.sh`
 
 Run: `./tests/test.sh`
 
+Additional dependencies:
+* docker-compose
+
 ## Publish on Docker Hub
 
 Run: `./publish.sh`
+
+Additional dependencies:
+* https://github.com/peritus/bumpversion
 
 ## License
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+echo "Waiting for database..."
+dockerize -timeout 240s -wait tcp://$HOST:$PORT
+echo
+
+function usage() { echo "Usage: $0 -h host -d database -p port -u username -w password [-v]" 1>&2; exit 1; }
+
+VERBOSE=0
+while getopts d:h:p:u:w:b:n: OPTION
+do
+  case $OPTION in
+    d)
+      DATABASE=$OPTARG
+      ;;
+    h)
+      HOST=$OPTARG
+      ;;
+    p)
+      PORT=$OPTARG
+      ;;
+    u)
+      USER=$OPTARG
+      ;;
+    w)
+      PASSWORD=$OPTARG
+      ;;
+    v)
+      VERBOSE=1
+      ;;
+    H)
+      usage
+  esac
+done
+
+echo "Install pgtap..."
+PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql > /dev/null 2>&1
+exit $?

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-function usage() { echo "Usage: $0 -h host -d database -p port -u username -w password -t 'tests/*.sql' [-v]" 1>&2; exit 1; }
+function usage() { echo "Usage: $0 -h host -d database -p port -u username -w password -t 'tests/*.sql' [-v] [-a] [-k]" 1>&2; exit 1; }
 
 VERBOSE=0
+INSTALL=1
+UNINSTALL=1
 while getopts d:h:p:u:w:b:n:t: OPTION
 do
   case $OPTION in
@@ -27,6 +29,12 @@ do
     v)
       VERBOSE=1
       ;;
+    a)
+      INSTALL=0
+      ;;
+    k)
+      UNINSTALL=0
+      ;;
     H)
       usage
       ;;
@@ -39,17 +47,19 @@ echo
 
 echo "Running tests: $TESTS"
 # install pgtap
-if [[ $VERBOSE == 1 ]] ; then
-  PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql
-else
-  PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql > /dev/null 2>&1
-fi
-rc=$?
+if [[ $INSTALL == 1 ]] ; then
+  if [[ $VERBOSE == 1 ]] ; then
+    PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql
+  else
+    PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/pgtap.sql > /dev/null 2>&1
+  fi
+  rc=$?
 
-# exit if pgtap failed to install
-if [[ $rc != 0 ]] ; then
-  echo "pgTap was not installed properly. Unable to run tests!"
-  exit $rc
+  # exit if pgtap failed to install
+  if [[ $rc != 0 ]] ; then
+    echo "pgTap was not installed properly. Unable to run tests!"
+    exit $rc
+  fi
 fi
 
 # run the tests
@@ -57,7 +67,9 @@ PGPASSWORD=$PASSWORD pg_prove -h $HOST -p $PORT -d $DATABASE -U $USER $TESTS
 rc=$?
 
 # uninstall pgtap
-PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/uninstall_pgtap.sql > /dev/null 2>&1
+if [[ $UNINSTALL == 1 ]] ; then
+  PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/uninstall_pgtap.sql > /dev/null 2>&1
+fi
 
 # exit with return code of the tests
 exit $rc

--- a/docker/uninstall.sh
+++ b/docker/uninstall.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+echo "Waiting for database..."
+dockerize -timeout 240s -wait tcp://$HOST:$PORT
+echo
+
+function usage() { echo "Usage: $0 -h host -d database -p port -u username -w password" 1>&2; exit 1; }
+
+while getopts d:h:p:u:w:b:n: OPTION
+do
+  case $OPTION in
+    d)
+      DATABASE=$OPTARG
+      ;;
+    h)
+      HOST=$OPTARG
+      ;;
+    p)
+      PORT=$OPTARG
+      ;;
+    u)
+      USER=$OPTARG
+      ;;
+    w)
+      PASSWORD=$OPTARG
+      ;;
+    H)
+      usage
+  esac
+done
+
+echo "Uninstall pgtap..."
+PGPASSWORD=$PASSWORD psql -h $HOST -p $PORT -d $DATABASE -U $USER -f /pgtap/sql/uninstall_pgtap.sql > /dev/null 2>&1
+exit $?


### PR DESCRIPTION
Thanks for your efforts, quite happily using this image :)

Minor annoyance has been while writing tests that it is annoying if the pgTap functions get uninstalled all the time.

So, this PR adds flags -a (for: assume installed, do not install) and -k (for: keep installed, do not uninstall) as well as two additional scripts for just doing install/uninstall.

I've ran tests locally and tested scripts locally but didn't add any tests for the new flags...seems like overkill. Modified images available to inspect at https://hub.docker.com/r/lsimons/pgtap .